### PR TITLE
Add investment vs crypto breakdown to dashboard summary

### DIFF
--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -3,7 +3,7 @@ require "digest/md5"
 class InvestmentStatement
   include Monetizable
 
-  monetize :total_contributions, :total_dividends, :total_interest, :unrealized_gains
+  monetize :total_contributions, :total_dividends, :total_interest, :unrealized_gains, :investment_only_value, :crypto_value
 
   attr_reader :family
 

--- a/app/models/investment_statement.rb
+++ b/app/models/investment_statement.rb
@@ -44,6 +44,23 @@ class InvestmentStatement
     Money.new(portfolio_value, family.currency)
   end
 
+  # Breakdown by account type
+  def investment_only_value
+    investment_accounts.select { |a| a.accountable_type == "Investment" }.sum(&:balance)
+  end
+
+  def crypto_value
+    investment_accounts.select { |a| a.accountable_type == "Crypto" }.sum(&:balance)
+  end
+
+  def has_crypto?
+    investment_accounts.any? { |a| a.accountable_type == "Crypto" }
+  end
+
+  def has_investments?
+    investment_accounts.any? { |a| a.accountable_type == "Investment" }
+  end
+
   # Total cash in investment accounts
   def cash_balance
     investment_accounts.sum(&:cash_balance)

--- a/app/views/pages/dashboard/_investment_summary.html.erb
+++ b/app/views/pages/dashboard/_investment_summary.html.erb
@@ -25,6 +25,29 @@
       </div>
     </div>
 
+    <% if investment_statement.has_investments? && investment_statement.has_crypto? %>
+      <div class="flex gap-4 px-4">
+        <div class="flex-1 bg-container-inset rounded-lg p-3">
+          <div class="flex items-center gap-2 mb-1">
+            <%= icon "chart-line", size: "sm", class: "text-secondary" %>
+            <p class="text-xs text-secondary"><%= t(".investments_label") %></p>
+          </div>
+          <p class="text-sm font-medium text-primary">
+            <%= format_money(Money.new(investment_statement.investment_only_value, Current.family.currency)) %>
+          </p>
+        </div>
+        <div class="flex-1 bg-container-inset rounded-lg p-3">
+          <div class="flex items-center gap-2 mb-1">
+            <%= icon "bitcoin", size: "sm", class: "text-secondary" %>
+            <p class="text-xs text-secondary"><%= t(".crypto_label") %></p>
+          </div>
+          <p class="text-sm font-medium text-primary">
+            <%= format_money(Money.new(investment_statement.crypto_value, Current.family.currency)) %>
+          </p>
+        </div>
+      </div>
+    <% end %>
+
     <% holdings = investment_statement.top_holdings(limit: 5) %>
     <% if holdings.any? %>
       <div class="bg-container-inset rounded-xl p-1 mx-4">

--- a/app/views/pages/dashboard/_investment_summary.html.erb
+++ b/app/views/pages/dashboard/_investment_summary.html.erb
@@ -33,7 +33,7 @@
             <p class="text-xs text-secondary"><%= t(".investments_label") %></p>
           </div>
           <p class="text-sm font-medium text-primary">
-            <%= format_money(Money.new(investment_statement.investment_only_value, Current.family.currency)) %>
+            <%= format_money(investment_statement.investment_only_value_money) %>
           </p>
         </div>
         <div class="flex-1 bg-container-inset rounded-lg p-3">
@@ -42,7 +42,7 @@
             <p class="text-xs text-secondary"><%= t(".crypto_label") %></p>
           </div>
           <p class="text-sm font-medium text-primary">
-            <%= format_money(Money.new(investment_statement.crypto_value, Current.family.currency)) %>
+            <%= format_money(investment_statement.crypto_value_money) %>
           </p>
         </div>
       </div>

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -46,6 +46,8 @@ en:
       investment_summary:
         title: "Investments"
         total_return: "Total Return"
+        investments_label: "Investments"
+        crypto_label: "Crypto"
         holding: "Holding"
         weight: "Weight"
         value: "Value"


### PR DESCRIPTION
## Summary

- Add visible breakdown showing Investments vs Crypto subtotals below the combined portfolio value on the dashboard
- The dashboard previously combined Investment and Crypto account balances into a single total ($23k), while the sidebar showed them separately (Investment $20k, Crypto $2.7k), causing confusion
- Breakdown only appears when both account types exist
- Uses existing Lucide icons (`chart-line` for investments, `bitcoin` for crypto) consistent with the account type models

## Changes

- `app/models/investment_statement.rb` — Add `investment_only_value`, `crypto_value`, `has_crypto?`, `has_investments?` methods
- `app/views/pages/dashboard/_investment_summary.html.erb` — Add two-column breakdown cards between the total and holdings table
- `config/locales/views/pages/en.yml` — Add `investments_label` and `crypto_label` translation keys

## Test plan

- [x] Navigate to dashboard with both Investment and Crypto accounts
- [x] Verify the combined total still shows at the top
- [x] Verify two breakdown cards appear below: "Investments" and "Crypto" with correct subtotals
- [x] Verify breakdown does NOT appear if user only has one account type
- [x] Run `bin/rails test` — no existing tests should break

🤖 Generated with [Claude Code](https://claude.com/claude-code)