### PR TITLE
Fix goal creation crash and add account linking

### DIFF
--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -2,7 +2,7 @@ class GoalsController < ApplicationController
   before_action :set_goal, only: %i[show edit update destroy]
 
   def index
-    @goals = Current.family.goals.by_priority
+    @goals = Current.family.goals.includes(:account).by_priority
   end
 
   def show
@@ -47,7 +47,8 @@ class GoalsController < ApplicationController
     def goal_params
       params.require(:goal).permit(
         :name, :description, :goal_type, :target_amount, :current_amount,
-        :target_date, :lucide_icon, :color, :priority, :is_completed, :currency
+        :target_date, :lucide_icon, :color, :priority, :is_completed, :currency,
+        :account_id
       )
     end
 end

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -28,10 +28,18 @@
 
     <%= f.text_area :description, label: t("goals.form.description"), rows: 2 %>
 
-    <div class="grid grid-cols-2 gap-4">
-      <%= f.number_field :target_amount, label: t("goals.form.target_amount"), required: true, min: 0, step: 0.01 %>
+    <%= f.number_field :target_amount, label: t("goals.form.target_amount"), required: true, min: 0, step: 0.01 %>
+
+    <% accounts = Current.family.accounts.visible.alphabetically %>
+    <% if accounts.any? %>
+      <%= f.select :account_id,
+            accounts.map { |a| [ "#{a.name} (#{format_money(a.balance_money)})", a.id ] },
+            { include_blank: t("goals.form.no_account"), label: t("goals.form.linked_account") } %>
+    <% end %>
+
+    <% unless goal.account_id.present? %>
       <%= f.number_field :current_amount, label: t("goals.form.current_amount"), min: 0, step: 0.01 %>
-    </div>
+    <% end %>
 
     <%= f.date_field :target_date, label: t("goals.form.target_date") %>
 

--- a/app/views/goals/_goal.html.erb
+++ b/app/views/goals/_goal.html.erb
@@ -37,6 +37,13 @@
     <span class="font-medium text-primary"><%= number_to_percentage(goal.progress_percent, precision: 0) %></span>
   </div>
 
+  <% if goal.account.present? %>
+    <p class="text-xs text-subdued mt-2 flex items-center gap-1">
+      <%= icon("landmark", size: "sm") %>
+      <%= goal.account.name %>
+    </p>
+  <% end %>
+
   <% if goal.target_date && !goal.is_completed %>
     <p class="text-xs text-subdued mt-2">
       <%= t("goals.show.days_remaining", count: goal.days_remaining) %>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -58,6 +58,13 @@
       </div>
     </div>
 
+    <% if @goal.account.present? %>
+      <div class="flex items-center gap-2 text-sm text-secondary mb-4">
+        <%= icon("landmark", size: "sm") %>
+        <span><%= t("goals.show.linked_to_account") %> <strong class="text-primary"><%= @goal.account.name %></strong></span>
+      </div>
+    <% end %>
+
     <%# Details %>
     <dl class="grid grid-cols-2 gap-4 pt-4 border-t border-primary">
       <div>

--- a/config/locales/views/goals/en.yml
+++ b/config/locales/views/goals/en.yml
@@ -28,6 +28,7 @@ en:
       on_track: On Track
       behind: Behind
       linked_categories: Linked Budget Categories
+      linked_to_account: Tracking balance from
       days_remaining:
         one: "%{count} day remaining"
         other: "%{count} days remaining"
@@ -43,6 +44,8 @@ en:
       mark_completed: Mark as completed
       cancel: Cancel
       no_goal: "(no goal)"
+      linked_account: Linked Account
+      no_account: "(none — enter amount manually)"
     types:
       emergency_fund: Emergency Fund
       vacation: Vacation

--- a/db/migrate/20260222220000_add_account_id_to_goals.rb
+++ b/db/migrate/20260222220000_add_account_id_to_goals.rb
@@ -1,0 +1,5 @@
+class AddAccountIdToGoals < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :goals, :account, type: :uuid, null: true, foreign_key: true
+  end
+end

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -67,6 +67,18 @@ class GoalTest < ActiveSupport::TestCase
     assert @goal.on_track?
   end
 
+  test "normalizes blank current_amount to zero" do
+    goal = Goal.new(family: @family, name: "Test", target_amount: 1000, currency: "USD", goal_type: "custom", current_amount: "")
+    goal.valid?
+    assert_equal 0, goal.current_amount
+  end
+
+  test "computed_current_amount uses account balance when linked" do
+    account = accounts(:depository)
+    @goal.update!(account: account)
+    assert_equal account.balance, @goal.computed_current_amount
+  end
+
   test "computed_current_amount uses current_amount when no linked categories" do
     assert_equal @goal.current_amount, @goal.computed_current_amount
   end


### PR DESCRIPTION
## Summary
- Fix `PG::NotNullViolation` crash when creating goals with blank `current_amount` — normalizes to 0
- Add optional account linking to goals so progress auto-tracks the account balance
- Account dropdown on goal form, linked account shown on cards and detail page

## Test plan
- [ ] Create a goal without filling in current amount — should no longer crash
- [ ] Create a goal linked to an account — progress should show account balance
- [ ] Edit a goal to unlink account — current amount field reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)